### PR TITLE
Add default blasfeo_LIBRARY and hpipm_LIBRARY default options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,20 @@ add_library(
   src/ocp_qp_ipm_solver_statistics.cpp
   src/ocp_qp_ipm_solver.cpp
 )
+
+if(NOT DEFINED blasfeo_LIBRARY)
+  set(blasfeo_LIBRARY ${blasfeo_DIR}/../lib/libblasfeo.so)
+endif()
+
+if(NOT DEFINED hpipm_LIBRARY)
+  set(hpipm_LIBRARY ${hpipm_DIR}/../lib/libhpipm.so)
+endif()
+
 target_link_libraries(
-  ${PROJECT_NAME} 
+  ${PROJECT_NAME}
   PUBLIC
-  ${blasfeo_DIR}/../lib/libblasfeo.so
-  ${hpipm_DIR}/../lib/libhpipm.so
+  ${blasfeo_LIBRARY}
+  ${hpipm_LIBRARY}
 )
 target_include_directories(
   ${PROJECT_NAME} 


### PR DESCRIPTION
I am trying to add hpipm-cpp and its dependencies to my cmake project using the ExternalProject_Add module. Unfortunately, there does not seem to be a way to do this using cmake args. For example, the source of hpipm needs to be changed to build as a shared lib.   

This PR adds a simple option to manual specify the blasfeo and hpipm locations. If the `blasfeo_LIBRARY` and `hpipm_LIBRARY` variables are not set, than the defaults will be used.